### PR TITLE
Add border color variable to Tailwind config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,8 @@ export default {
         primary: 'hsl(var(--primary))'
       },
       borderColor: {
-        DEFAULT: 'hsl(var(--border))'
+        DEFAULT: 'hsl(var(--border))',
+        border: 'hsl(var(--border))'
       }
     }
   },


### PR DESCRIPTION
## Summary
- define a `border` entry in `borderColor` for tailwind theme

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689b34264554832e94daadcf44fd2a47