### PR TITLE
feat: refine job type structure

### DIFF
--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -3,11 +3,11 @@ import type { Job } from '@/types'
 export default function JobCard({ job }: { job: Job }) {
   return (
     <article className="rounded-lg border p-4 mb-4">
-      <h3 className="text-lg font-semibold">{job.title}</h3>
-      <p className="text-sm text-gray-600">{job.companyName}</p>
-      <p className="mt-2 whitespace-pre-wrap">{job.description}</p>
-      {/* Show ads ONLY for admin posts */}
-      {job.isAdminPost && <AdSenseBlock />}
-    </article>
-  )
-}
+        <h3 className="text-lg font-semibold">{job.title}</h3>
+        <p className="text-sm text-gray-600">{job.company}</p>
+        <p className="mt-2 whitespace-pre-wrap">{job.description}</p>
+        {/* Show ads when allowed */}
+        {job.showAds && <AdSenseBlock />}
+      </article>
+    )
+  }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,39 @@
+import type { Timestamp } from 'firebase/firestore'
+
+export type FirebaseTimestamp = Timestamp
+
 export type Role = 'admin' | 'company' | 'user'
+
+export type EmploymentType =
+  | 'full-time'
+  | 'part-time'
+  | 'contract'
+  | 'temporary'
+  | 'internship'
+  | 'volunteer'
+  | 'other'
+
+export type JobStatus = 'draft' | 'published' | 'closed'
 
 export type Job = {
   id: string
   title: string
+  company: string
+  location: string
+  category: string
+  tags: string[]
+  employmentType: EmploymentType
+  salaryMin?: number
+  salaryMax?: number
+  currency: string
+  summary: string
   description: string
-  companyName: string
-  isAdminPost: boolean
-  createdBy: string
-  createdAt?: { seconds: number; nanoseconds: number } | null
+  sourceUrl: string
+  applyUrl: string
+  postedAt: FirebaseTimestamp
+  expiresAt?: FirebaseTimestamp
+  source: string
+  showAds: boolean
+  status: JobStatus
+  updatedAt: FirebaseTimestamp
 }


### PR DESCRIPTION
## Summary
- expand `Job` type with company, location, employment details, salary range, links, timestamps, and ad/display metadata
- alias `FirebaseTimestamp` to Firestore's `Timestamp`
- adjust `JobCard` to display new job fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module '@\/integrations/firebase' has no exported members)*

------
https://chatgpt.com/codex/tasks/task_e_68a597bd78bc832ea78f65f0a2f61e2a